### PR TITLE
Update SocketAbstraction.cs

### DIFF
--- a/src/Renci.SshNet/ForwardedPortLocal.cs
+++ b/src/Renci.SshNet/ForwardedPortLocal.cs
@@ -359,7 +359,7 @@ namespace Renci.SshNet
 
         private static void CloseClientSocket(Socket clientSocket)
         {
-            if (clientSocket.Connected)
+            if (clientSocket is not null && clientSocket.Connected)
             {
                 try
                 {
@@ -371,7 +371,7 @@ namespace Renci.SshNet
                 }
             }
 
-            clientSocket.Dispose();
+            clientSocket?.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
in ReadContinuous socket can be null.  Especially when only a few bytes 100 are sent and then disposed ASAP (Using Async Methods).

In our code socket would be null by the time it got to:
 socket.ReceiveTimeout = 0; threw NullReferenceException 

Linux happens almost every time.  Windows not so much.

The issue cause performance problems and other side affects like kestrel crashing. 